### PR TITLE
List github issues as the bug tracker?

### DIFF
--- a/unix-bytestring.cabal
+++ b/unix-bytestring.cabal
@@ -11,6 +11,7 @@ Name:           unix-bytestring
 Version:        0.3.7.3
 Stability:      provisional
 Homepage:       http://code.haskell.org/~wren/
+Bug-Reports:    http://github.com/wrengr/unix-bytestring/issues
 Author:         wren gayle romano
 Maintainer:     wren@community.haskell.org
 Copyright:      Copyright (c) 2010--2015 wren gayle romano


### PR DESCRIPTION
I was initially a bit hesitant to invest time into trying out this package without any place to see active issues/PRs. Would you be comfortable listing github as the main issue tracker? (It's not immediately obvious, coming from hackage, that this github repo exists).