### PR TITLE
Fix cross-compilation for aarch64

### DIFF
--- a/src/System/Posix/Types/Iovec.hsc
+++ b/src/System/Posix/Types/Iovec.hsc
@@ -52,8 +52,10 @@ data CIovec = CIovec
     , iov_len  :: {-# UNPACK #-} !CSize       -- size_t
     }
 
+#if __GLASGOW_HASKELL__ < 800
 #let alignment t = \
     "%lu", (unsigned long) offsetof(struct {char x__; t (y__); }, y__)
+#endif
 
 instance Storable CIovec where
     alignment _ = #{alignment struct iovec}


### PR DESCRIPTION
Disable hsc_alignment for more recent GHC releases, per https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/8.0#hsc2hs-defines-an-alignment-macro